### PR TITLE
Delay repo creation until after the image is built

### DIFF
--- a/.github/workflows/ecr-publish.yml
+++ b/.github/workflows/ecr-publish.yml
@@ -38,7 +38,7 @@ jobs:
           [ "${VISIBILITY}" == "public" ] && VISIBILITY="public"
           echo "export VISIBILITY='${VISIBILITY}'" > .env
 
-      - name: Create ECR Repo
+      - name: Indentify the image repo being built
         run: |
           source .env
 
@@ -74,6 +74,77 @@ jobs:
           # IMAGE_URI+="/${ENVIRONMENT}"
           IMAGE_URI+="/${IMAGE_NAME}"
 
+          # Stow the computed values for future consumption
+          echo "export PRODUCT_SUITE=${PRODUCT_SUITE@Q}" >> .env
+          echo "export ENVIRONMENT=${ENVIRONMENT@Q}" >> .env
+          echo "export IMAGE_NAME=${IMAGE_NAME@Q}" >> .env
+          echo "export IMAGE_URI=${IMAGE_URI@Q}" >> .env
+
+      - name: Build Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          source .env
+
+          # Parse out the tag, handle the case when it's not there
+          export TAG="$(
+              set -euo pipefail
+
+              # Parsing out the version from the "VER" argument can be tricky if it's computed from others
+              # values or arguments, so let's try it with some sneaky trickery.
+
+              # TODO: There's an edge case here where there are more than one FROM clauses, and argument
+              # values are redefined ... but that's too complex for now, so let's KISS it and move on
+
+              # We have to resort to Perl's evil black magic b/c we have to cover the edge case of
+              # line continuations - we have to collapse those, first... then we can find the ARG clauses,
+              # and finally convert them all into bash "export" clauses ... which we then consume (this is
+              # why redefinition is an issue, above)
+              perl -pe 's/\\\s*\n/ /' Dockerfile | \
+                  grep "^[[:space:]]*ARG[[:space:]]" | \
+                  grep "=" | \
+                  sed -e 's;^\s*ARG\s;export ;g' > .versionParse
+
+              # Load the parsed arguments, now "export" clauses
+              source .versionParse
+
+              # Cleanup...
+              rm -f .versionParse
+
+              # TODO: do we want to support many possible version sources? i.e. VER, VERSION,
+              # IMAGEVER, IMAGE_VERSION, etc?
+              [ -v VER ] && [ -n "${VER}" ] && echo -n "${VER}"
+          )"
+          [ -n "${TAG}" ] || TAG="latest"
+          [ "${ENVIRONMENT}" != "stable" ] && TAG="${ENVIRONMENT}-${TAG}"
+          echo "export IMAGE_TAG=${TAG@Q}" >> .env
+          cat .env
+          export IMAGE_FULL_URI="${ECR_REGISTRY}/${IMAGE_URI}"
+          echo "export IMAGE_FULL_URI=${IMAGE_FULL_URI@Q}" >> .env
+          export BUILD="${IMAGE_FULL_URI}:${TAG}"
+          echo "export BUILDS=()" >> .env
+          echo "BUILDS+=(${BUILD@Q})" >> .env
+
+          # Set any build arguments with private values
+          export BUILD_ARGS=()
+          # First off - the base registry for the images
+          BUILD_ARGS+=(--build-arg "BASE_REGISTRY=${ECR_REGISTRY}")
+
+          # Set the build tags to be built
+          export TAGS=(--tag "${BUILD}")
+          if [ "${ENVIRONMENT}" == "stable" ] ; then
+              export LATEST="${IMAGE_FULL_URI}:latest"
+              echo "BUILDS+=(${LATEST@Q})" >> .env
+              TAGS+=(--tag "${LATEST}")
+          else
+              echo "latest tag not required"
+          fi
+          docker build "${BUILD_ARGS[@]}" "${TAGS[@]}" .
+
+      - name: Create ECR Repo
+        run: |
+          source .env
+
           echo "We are creating an image for the ${GITHUB_REPOSITORY}@${ENVIRONMENT}. This is based off of the repository name and Git branch."
           echo "We try creating this even if the repo exists, so errors to that note will not create failures of the workflow."
           aws ecr create-repository \
@@ -82,12 +153,6 @@ jobs:
              --image-tag-mutability MUTABLE \
              --image-scanning-configuration scanOnPush=true  \
              --encryption-configuration encryptionType="AES256" || true
-
-          # Stow the computed values for future consumption
-          echo "export PRODUCT_SUITE=${PRODUCT_SUITE@Q}" >> .env
-          echo "export ENVIRONMENT=${ENVIRONMENT@Q}" >> .env
-          echo "export IMAGE_NAME=${IMAGE_NAME@Q}" >> .env
-          echo "export IMAGE_URI=${IMAGE_URI@Q}" >> .env
 
       - name: Create Access Permissions
         run: |
@@ -167,66 +232,6 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build Docker image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          source .env
-          # Parse out the tag, handle the case when it's not there
-          export TAG="$(
-              set -euo pipefail
-
-              # Parsing out the version from the "VER" argument can be tricky if it's computed from others
-              # values or arguments, so let's try it with some sneaky trickery.
-
-              # TODO: There's an edge case here where there are more than one FROM clauses, and argument
-              # values are redefined ... but that's too complex for now, so let's KISS it and move on
-
-              # We have to resort to Perl's evil black magic b/c we have to cover the edge case of
-              # line continuations - we have to collapse those, first... then we can find the ARG clauses,
-              # and finally convert them all into bash "export" clauses ... which we then consume (this is
-              # why redefinition is an issue, above)
-              perl -pe 's/\\\s*\n/ /' Dockerfile | \
-                  grep "^[[:space:]]*ARG[[:space:]]" | \
-                  grep "=" | \
-                  sed -e 's;^\s*ARG\s;export ;g' > .versionParse
- 
-              # Load the parsed arguments, now "export" clauses
-              source .versionParse
-
-              # Cleanup...
-              rm -f .versionParse
-
-              # TODO: do we want to support many possible version sources? i.e. VER, VERSION,
-              # IMAGEVER, IMAGE_VERSION, etc?
-              [ -v VER ] && [ -n "${VER}" ] && echo -n "${VER}"
-          )"
-          [ -n "${TAG}" ] || TAG="latest"
-          [ "${ENVIRONMENT}" != "stable" ] && TAG="${ENVIRONMENT}-${TAG}"
-          echo "export IMAGE_TAG=${TAG@Q}" >> .env
-          cat .env
-          export IMAGE_FULL_URI="${ECR_REGISTRY}/${IMAGE_URI}"
-          echo "export IMAGE_FULL_URI=${IMAGE_FULL_URI@Q}" >> .env
-          export BUILD="${IMAGE_FULL_URI}:${TAG}"
-          echo "export BUILDS=()" >> .env
-          echo "BUILDS+=(${BUILD@Q})" >> .env
-
-          # Set any build arguments with private values
-          export BUILD_ARGS=()
-          # First off - the base registry for the images
-          BUILD_ARGS+=(--build-arg "BASE_REGISTRY=${ECR_REGISTRY}")
-
-          # Set the build tags to be built
-          export TAGS=(--tag "${BUILD}")
-          if [ "${ENVIRONMENT}" == "stable" ] ; then
-              export LATEST="${IMAGE_FULL_URI}:latest"
-              echo "BUILDS+=(${LATEST@Q})" >> .env
-              TAGS+=(--tag "${LATEST}")
-          else
-              echo "latest tag not required"
-          fi
-          docker build "${BUILD_ARGS[@]}" "${TAGS[@]}" .
 
       - name: Publish Docker image
         env:

--- a/.github/workflows/ecr-publish.yml
+++ b/.github/workflows/ecr-publish.yml
@@ -100,20 +100,26 @@ jobs:
               # line continuations - we have to collapse those, first... then we can find the ARG clauses,
               # and finally convert them all into bash "export" clauses ... which we then consume (this is
               # why redefinition is an issue, above)
-              perl -pe 's/\\\s*\n/ /' Dockerfile | \
-                  grep "^[[:space:]]*ARG[[:space:]]" | \
-                  grep "=" | \
-                  sed -e 's;^\s*ARG\s;export ;g' > .versionParse
+              source <(
+                  perl -pe 's/\\\s*$//' Dockerfile | \
+                      grep "^[[:space:]]*ARG[[:space:]]" | \
+                      grep "=" | \
+                      sed -e 's;^\s*ARG\s;export ;g'
+              )
 
-              # Load the parsed arguments, now "export" clauses
-              source .versionParse
-
-              # Cleanup...
-              rm -f .versionParse
-
+              CANDIDATES=()
+              CANDIDATES+=("VER")
               # TODO: do we want to support many possible version sources? i.e. VER, VERSION,
               # IMAGEVER, IMAGE_VERSION, etc?
-              [ -v VER ] && [ -n "${VER}" ] && echo -n "${VER}"
+              # CANDIDATES+=("VERSION")
+              # CANDIDATES+=("IMAGEVER")
+              # CANDIDATES+=("IMAGEVERSION")
+              # CANDIDATES+=("IMAGE_VERSION")
+              for C in "${CANDIDATES[@]}" ; do
+                  # This checks to see if the candidate is defined, and if it has a non-blank
+                  # value. If both are met, then its value is output, and the loop is broken
+                  [ -v "${C}" ] && [ -n "${!C}" ] && echo -n "${!C}" && break
+              done
           )"
           [ -n "${TAG}" ] || TAG="latest"
           [ "${ENVIRONMENT}" != "stable" ] && TAG="${ENVIRONMENT}-${TAG}"


### PR DESCRIPTION
- This way we won't fill the ECR registry with garbage until we're actually going to push something in